### PR TITLE
fix: add workarounds to build workflow for bugs in upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: auth0 --version
+          gitref: ${{ github.head_ref }} # workaround for https://github.com/asdf-vm/asdf/issues/2131
+          version: "1.21.0" # latest version as of 2025-10-09, workaround for https://github.com/asdf-vm/asdf/issues/2193


### PR DESCRIPTION
Found that the `asdf plugin test` command used by the action is affected by multiple bugs:

* https://github.com/asdf-vm/asdf/issues/2193
* https://github.com/asdf-vm/asdf/issues/2131